### PR TITLE
specify the host

### DIFF
--- a/server.py
+++ b/server.py
@@ -41,4 +41,4 @@ def comments_handler():
 
 
 if __name__ == '__main__':
-    app.run(port=int(os.environ.get("PORT", 3000)))
+    app.run(host='0.0.0.0',port=int(os.environ.get("PORT", 3000)))


### PR DESCRIPTION
without the host as a parameter of app.run() function, the default host will be the 127.0.0.1 which is a loopback address only for local machine. External user will be unable to connect to the server.